### PR TITLE
ZON-3228: Adapt imports for `Result`.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,7 +6,6 @@ News
 
 - ZON-3364: Implement ``IWhitelist.locations()``.
 
-- Update to `zeit.cms >= 2.90`.
 
 2.4.0 (2016-09-16)
 ------------------

--- a/src/zeit/intrafind/whitelist.py
+++ b/src/zeit/intrafind/whitelist.py
@@ -3,6 +3,7 @@ import collections
 import gocept.lxml.objectify
 import logging
 import urllib2
+import zeit.cms.result
 import zeit.cms.tagging.interfaces
 import zeit.intrafind.tag
 import zope.interface
@@ -65,7 +66,7 @@ class Topicpages(object):
     def get_topics(self, start=0, rows=25):
         whitelist = zope.component.getUtility(
             zeit.cms.tagging.interfaces.IWhitelist)
-        result = zeit.cms.tagging.interfaces.Result()
+        result = zeit.cms.result.Result()
         result.hits = len(whitelist.data)
         for tag in whitelist.data.values()[start:start + rows]:
             result.append({

--- a/src/zeit/intrafind/whitelist.py
+++ b/src/zeit/intrafind/whitelist.py
@@ -3,7 +3,7 @@ import collections
 import gocept.lxml.objectify
 import logging
 import urllib2
-import zeit.cms.result
+import zeit.cms.interfaces
 import zeit.cms.tagging.interfaces
 import zeit.intrafind.tag
 import zope.interface
@@ -66,7 +66,7 @@ class Topicpages(object):
     def get_topics(self, start=0, rows=25):
         whitelist = zope.component.getUtility(
             zeit.cms.tagging.interfaces.IWhitelist)
-        result = zeit.cms.result.Result()
+        result = zeit.cms.interfaces.Result()
         result.hits = len(whitelist.data)
         for tag in whitelist.data.values()[start:start + rows]:
             result.append({


### PR DESCRIPTION
requries ZeitOnline/zeit.cms#30
